### PR TITLE
reverting to 29 temporarily

### DIFF
--- a/fedora
+++ b/fedora
@@ -1,4 +1,4 @@
-FROM fedora:rawhide
+FROM fedora:29
 RUN dnf install -y sudo make cmake automake autoconf libtool git vim-minimal gcc-c++ gcc-gfortran flex patch doxygen graphviz pandoc python2 openmpi-devel redhat-rpm-config hdf5-openmpi-devel exodusii-devel cereal-devel lapack-devel scotch-devel metis-devel environment-modules python-pip python3-pip clang llvm compiler-rt ccache texlive-epstopdf-bin ghostscript-core texlive-latex-bin-bin texlive-collection-fontsrecommended texlive-fancyhdr findutils texlive-booktabs gdb wget curl lcov boost-devel hwloc-devel hpx-openmpi-devel clang-devel llvm-devel
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage

--- a/fedora_mpich
+++ b/fedora_mpich
@@ -1,4 +1,4 @@
-FROM fedora:latest
+FROM fedora:29
 RUN dnf install -y sudo make cmake automake autoconf libtool git vim-minimal gcc-c++ gcc-gfortran flex patch doxygen graphviz pandoc python2 mpich-devel redhat-rpm-config hdf5-mpich-devel exodusii-devel cereal-devel lapack-devel scotch-devel metis-devel environment-modules python-pip python3-pip clang llvm compiler-rt ccache texlive-epstopdf-bin ghostscript-core texlive-latex-bin-bin texlive-collection-fontsrecommended texlive-fancyhdr findutils texlive-booktabs gdb wget curl lcov boost-devel hwloc-devel hpx-mpich-devel clang-devel llvm-devel
 RUN wget -O /usr/bin/doxy-coverage https://raw.githubusercontent.com/alobbs/doxy-coverage/master/doxy-coverage.py
 RUN chmod +x /usr/bin/doxy-coverage


### PR DESCRIPTION
Temporarily revert back to Fedora 29, so we can revert the changes in third-party to create a working base container again for FleCSI. Then we can go back to rawhide and keep working through the unit tests failures.